### PR TITLE
chore: デプロイコマンドを削除

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -73,15 +73,3 @@ jobs:
 
             - name: アプリのビルドとGASへのプッシュ
               run: make build-and-push
-
-            - name: デプロイの新バージョンを作成
-              run: |
-                  VERSION_OUTPUT=$(clasp version "Auto-deploy from GitHub Actions")
-                  echo "VERSION_OUTPUT: $VERSION_OUTPUT"
-                  VERSION_NUMBER=$(echo $VERSION_OUTPUT | grep -oP '(?<=Created version )\d+')
-                  echo "Version number: '$VERSION_NUMBER'"
-                  echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
-
-            - name: GASへデプロイ
-              run: |
-                  clasp deploy --deploymentId '${{ secrets.GAS_DEPLOYMENT_ID }}' --versionNumber ${{ env.VERSION_NUMBER }}

--- a/.github/workflows/stg.yml
+++ b/.github/workflows/stg.yml
@@ -74,15 +74,3 @@ jobs:
 
             - name: アプリのビルドとstg環境GASへのプッシュ
               run: make build-and-push
-
-            - name: デプロイの新バージョンを作成
-              run: |
-                  VERSION_OUTPUT=$(clasp version "Auto-deploy from GitHub Actions")
-                  echo "VERSION_OUTPUT: $VERSION_OUTPUT"
-                  VERSION_NUMBER=$(echo $VERSION_OUTPUT | grep -oP '(?<=Created version )\d+')
-                  echo "Version number: '$VERSION_NUMBER'"
-                  echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
-
-            - name: stg環境GASへデプロイ
-              run: |
-                  clasp deploy --deploymentId '${{ secrets.GAS_DEPLOYMENT_ID_STG }}' --versionNumber ${{ env.VERSION_NUMBER }}


### PR DESCRIPTION
`clasp deploy`をするとライブラリとしてデプロイされてしまうらしい。
そうするとURLが変わってしまいAPIとして利用できないので、一度Revertする。