### PR TITLE
fix: 週次レポートで来週予定を合算しない

### DIFF
--- a/.github/workflows/stg.yml
+++ b/.github/workflows/stg.yml
@@ -24,7 +24,7 @@ jobs:
             # コード内で置換される変数
             TARGET_EMAIL_ADDRESS: ${{ secrets.TARGET_EMAIL_ADDRESS_STG }}
             TARGET_SHEET_NAME: "金銭メモstg"
-            TEST_DATE: "20260210"
+            TEST_DATE: "20260208"
 
         steps:
             - name: リポジトリのチェックアウト

--- a/scripts/formatting/summaryMessageFormatter.js
+++ b/scripts/formatting/summaryMessageFormatter.js
@@ -1,15 +1,12 @@
 function handleWeeklySummaryResult(dateRangeStr, totalAmount, dataEntries, difference, percentage, adjustedBudget, isStaging, action, currentDate) {
-    var upcomingPlannedExpenses = getPlannedExpensesForCurrentWeek(currentDate);
-    var upcomingExpenseLines = formatUpcomingPlannedExpenseLines(upcomingPlannedExpenses);
-    var plannedExpenseTotal = calculatePlannedExpenseTotal(upcomingPlannedExpenses);
+    var nextWeekPlannedExpenses = getPlannedExpensesForNextWeek(currentDate);
+    var nextWeekExpenseLines = formatUpcomingPlannedExpenseLines(nextWeekPlannedExpenses);
+    var nextWeekPlannedExpenseTotal = calculatePlannedExpenseTotal(nextWeekPlannedExpenses);
     var weeklyBudgetCarryoverMemo = getWeeklyBudgetCarryoverMemoForWeek(currentDate);
     var weeklyAnalysisMode = getWeeklyAnalysisMode(currentDate);
     var differenceSign = difference >= 0 ? "+" : "-";
     var differenceAbs = Math.abs(difference);
     var percentageStr = percentage.toFixed(2);
-    var projectedPercentage = adjustedBudget
-        ? (((totalAmount + plannedExpenseTotal) / adjustedBudget) * 100).toFixed(2)
-        : "0.00";
     var categoryRankingLines = getCategoryRankingLines(dataEntries);
     var top5Entries = getTopExpenseEntries(dataEntries, 5);
     var body = "";
@@ -17,12 +14,9 @@ function handleWeeklySummaryResult(dateRangeStr, totalAmount, dataEntries, diffe
     body += "◆ " + dateRangeStr + " の週次サマリー\n\n";
     body += "++++++++++ 💸 予算サマリー 💸 ++++++++++\n";
     body += dateRangeStr + " の実支出: " + totalAmount + " 円\n";
-    body += "今後の予定金額: " + plannedExpenseTotal + " 円\n";
-    body += "支出＋予定の合計見込み: " + (totalAmount + plannedExpenseTotal) + " 円\n";
     body += "\n";
     body += "予算に対して\n";
     body += "・実支出: " + percentageStr + "%\n";
-    body += "・合計見込み: " + projectedPercentage + "%\n";
     body += "（設定予算：" + adjustedBudget + "円）\n";
     body += "・分析モード: " + formatWeeklyAnalysisModeForMessage(weeklyAnalysisMode) + "\n";
     body += "++++++++++++++++++++++++++++++++++++\n";
@@ -48,9 +42,10 @@ function handleWeeklySummaryResult(dateRangeStr, totalAmount, dataEntries, diffe
         body += "・" + formatDate(entry.date) + " - " + entry.name + ": " + entry.amount + "円\n";
     });
     body += "\n";
-    body += "◆ 直近の予定支出\n";
-    if (upcomingExpenseLines.length) {
-        upcomingExpenseLines.forEach(function (line) {
+    body += "◆ 来週の支出予定\n";
+    if (nextWeekExpenseLines.length) {
+        body += "合計見込み: " + nextWeekPlannedExpenseTotal + "円\n";
+        nextWeekExpenseLines.forEach(function (line) {
             body += line + "\n";
         });
     } else {
@@ -58,7 +53,10 @@ function handleWeeklySummaryResult(dateRangeStr, totalAmount, dataEntries, diffe
     }
     body += "\n";
 
-    var geminiAnalysis = analyzeExpensesWithGemini(dataEntries, totalAmount, adjustedBudget, percentage, currentDate, weeklyAnalysisMode);
+    var geminiAnalysis = analyzeExpensesWithGemini(dataEntries, totalAmount, adjustedBudget, percentage, currentDate, weeklyAnalysisMode, {
+        plannedExpenses: nextWeekPlannedExpenses,
+        plannedExpenseLabel: "来週の予定メモ"
+    });
     if (geminiAnalysis) {
         body += "◆ Gemini分析\n" + geminiAnalysis + "\n";
     } else {

--- a/scripts/infrastructure/gemini/expenseSummaryGemini.js
+++ b/scripts/infrastructure/gemini/expenseSummaryGemini.js
@@ -1,13 +1,15 @@
-function analyzeExpensesWithGemini(dataEntries, totalAmount, adjustedBudget, percentage, baseDate, weeklyAnalysisMode) {
+function analyzeExpensesWithGemini(dataEntries, totalAmount, adjustedBudget, percentage, baseDate, weeklyAnalysisMode, options) {
     var apiKey = getGeminiApiKey();
+    var analysisOptions = options || {};
+    var plannedExpenses = analysisOptions.plannedExpenses || getUpcomingPlannedExpenses(baseDate);
+    var plannedExpenseLabel = analysisOptions.plannedExpenseLabel || "今後の予定メモ";
     if (!apiKey) {
         return null;
     }
     var expenseLines = dataEntries.map(function (entry) {
         return formatDate(entry.date) + " [" + (entry.category || "未分類") + "] " + entry.name + " " + entry.amount + "円";
     });
-    var upcomingPlannedExpenses = getUpcomingPlannedExpenses(baseDate);
-    var upcomingExpenseLines = upcomingPlannedExpenses.map(function (entry) {
+    var upcomingExpenseLines = plannedExpenses.map(function (entry) {
         return formatDate(entry.date) + " [" + entry.title + "] " + entry.memo;
     });
     var categoryRankingLines = getCategoryRankingLines(dataEntries);
@@ -25,6 +27,7 @@ function analyzeExpensesWithGemini(dataEntries, totalAmount, adjustedBudget, per
         weeklyAnalysisModeGuidance,
         weeklyBudgetCarryoverMemo,
         weeklyBudgetCarryoverGuidance,
+        plannedExpenseLabel,
         upcomingExpenseLines
     );
 
@@ -51,6 +54,7 @@ function buildExpenseSummaryPrompt(
     weeklyAnalysisModeGuidance,
     weeklyBudgetCarryoverMemo,
     weeklyBudgetCarryoverGuidance,
+    plannedExpenseLabel,
     upcomingExpenseLines
 ) {
     var expenseLines = dataEntries.map(function (entry) {
@@ -74,7 +78,7 @@ function buildExpenseSummaryPrompt(
         "分析モードの反映方針: " + weeklyAnalysisModeGuidance,
         "前週の予算差分メモ: " + formatWeeklyBudgetCarryoverMemoForPrompt(weeklyBudgetCarryoverMemo),
         "前週差分の反映方針: " + weeklyBudgetCarryoverGuidance,
-        "今後の予定メモ: " + (upcomingExpenseLines.length ? upcomingExpenseLines.join(" / ") : "なし"),
+        plannedExpenseLabel + ": " + (upcomingExpenseLines.length ? upcomingExpenseLines.join(" / ") : "なし"),
         "以下は支出一覧(日付、カテゴリ、名称、金額)です。名称だけで内容が不明瞭な場合はカテゴリから内容を推定してください:",
         expenseLines.join("\n")
     ].join("\n");
@@ -131,6 +135,15 @@ function getPlannedExpensesForCurrentWeek(baseDate) {
     var startDate = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
     var endDateExclusive = new Date(range.endDate);
     endDateExclusive.setDate(endDateExclusive.getDate() + 1);
+    return getPlannedExpensesInRange(startDate, endDateExclusive);
+}
+
+function getPlannedExpensesForNextWeek(baseDate) {
+    var range = getWeekRange(baseDate);
+    var startDate = new Date(range.endDate);
+    var endDateExclusive = new Date(range.endDate);
+    startDate.setDate(startDate.getDate() + 1);
+    endDateExclusive.setDate(endDateExclusive.getDate() + 8);
     return getPlannedExpensesInRange(startDate, endDateExclusive);
 }
 


### PR DESCRIPTION
## 概要
- Issue #64 の対応
- 週次レポートでは、その週の実支出だけで予算評価するように修正
- 来週の予定支出は合算せず、別枠の注意喚起として扱う

## 変更内容
- 週次レポートの予算サマリーから `今後の予定金額` と `支出＋予定の合計見込み` を削除
- 週次レポートに `来週の支出予定` セクションを追加
- 来週予定の合計見込みは別枠で表示し、今週の予算差分計算には含めない
- Gemini の週次分析では、来週予定を補助情報として渡しつつ、今週の締め計算には混ぜないように変更
- 日次レポートの挙動は変更しない

## 期待される挙動
- 週次レポートでは、その週の日曜分までの実支出だけで予算比率と差分が決まる
- 翌週の予定は `来週の支出予定` として見えるが、今週の支出合計には足されない
- 次週に大きめの予定がある場合でも、週次レポートは「今週の締め」と「来週への注意」を分けて表示する

## 確認
- `npm run build`
- メールを確認
<img width="468" height="219" alt="image" src="https://github.com/user-attachments/assets/25cc5c9f-fdae-47eb-8d4b-f769e4550ea1" />
