### PR TITLE
feat: 記録済みの支出予定をサマリから除外する

### DIFF
--- a/.github/workflows/stg.yml
+++ b/.github/workflows/stg.yml
@@ -24,7 +24,7 @@ jobs:
             # コード内で置換される変数
             TARGET_EMAIL_ADDRESS: ${{ secrets.TARGET_EMAIL_ADDRESS_STG }}
             TARGET_SHEET_NAME: "金銭メモstg"
-            TEST_DATE: "20260208"
+            TEST_DATE: "20260210"
 
         steps:
             - name: リポジトリのチェックアウト

--- a/scripts/infrastructure/gemini/expenseSummaryGemini.js
+++ b/scripts/infrastructure/gemini/expenseSummaryGemini.js
@@ -180,6 +180,7 @@ function getPlannedExpensesInRange(startDate, endDate) {
     });
 
     plannedExpenses = cleanPlannedExpenseMemosWithGemini(plannedExpenses);
+    plannedExpenses = filterRecordedPlannedExpenses(plannedExpenses);
 
     plannedExpenses.sort(function (a, b) {
         return a.date.getTime() - b.date.getTime();
@@ -188,6 +189,190 @@ function getPlannedExpensesInRange(startDate, endDate) {
     Logger.log("予定支出取得件数: " + plannedExpenses.length);
 
     return plannedExpenses;
+}
+
+function filterRecordedPlannedExpenses(plannedExpenses) {
+    if (!plannedExpenses.length) {
+        return plannedExpenses;
+    }
+
+    var actualEntries = getExpenseEntriesForDates(buildExpenseComparisonDates(plannedExpenses));
+
+    return plannedExpenses.filter(function (plannedExpense) {
+        var candidateEntries = findRecordedExpenseCandidates(plannedExpense, actualEntries);
+        var shouldExclude = shouldExcludePlannedExpense(plannedExpense, candidateEntries);
+
+        if (shouldExclude) {
+            Logger.log(
+                "記録済み予定を除外: " +
+                    formatDate(plannedExpense.date) +
+                    " title=" +
+                    plannedExpense.title +
+                    " memo=" +
+                    plannedExpense.memo
+            );
+        }
+
+        return !shouldExclude;
+    });
+}
+
+function buildExpenseComparisonDates(plannedExpenses) {
+    var dateMap = {};
+    var dates = [];
+
+    plannedExpenses.forEach(function (plannedExpense) {
+        [-1, 0, 1].forEach(function (offset) {
+            var date = new Date(plannedExpense.date);
+            var key;
+            date.setDate(date.getDate() + offset);
+            key = date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
+            if (!dateMap[key]) {
+                dateMap[key] = true;
+                dates.push(new Date(date.getFullYear(), date.getMonth(), date.getDate()));
+            }
+        });
+    });
+
+    return dates;
+}
+
+function findRecordedExpenseCandidates(plannedExpense, actualEntries) {
+    var plannedAmounts = extractPlannedExpenseAmounts(plannedExpense);
+    var plannedText = [plannedExpense.title || "", plannedExpense.memo || ""].join(" ");
+    var plannedNormalized = normalizeExpenseComparisonText(plannedText);
+
+    return actualEntries.filter(function (entry) {
+        var dayDistance = Math.abs(calculateDateDistanceInDays(plannedExpense.date, entry.date));
+        var actualAmount = parseFloat(entry.amount);
+        var sharedTokenCount = countSharedExpenseTokens(plannedText, [entry.name || "", entry.category || ""].join(" "));
+        var amountMatched = !plannedAmounts.length || plannedAmounts.some(function (plannedAmount) {
+            return !isNaN(actualAmount) && Math.abs(plannedAmount - actualAmount) <= 300;
+        });
+        var nameNormalized = normalizeExpenseComparisonText(entry.name || "");
+        var containsMatchedName = !!nameNormalized && (
+            plannedNormalized.indexOf(nameNormalized) !== -1 ||
+            nameNormalized.indexOf(plannedNormalized) !== -1
+        );
+
+        if (dayDistance > 1) {
+            return false;
+        }
+
+        return amountMatched || sharedTokenCount > 0 || containsMatchedName;
+    });
+}
+
+function shouldExcludePlannedExpense(plannedExpense, candidateEntries) {
+    if (!candidateEntries.length) {
+        return false;
+    }
+
+    var exactRuleMatch = findExactRecordedExpenseMatch(plannedExpense, candidateEntries);
+    if (exactRuleMatch) {
+        return true;
+    }
+
+    var geminiCandidates = candidateEntries.filter(function (entry) {
+        return isStrongExpenseCandidateForGemini(plannedExpense, entry);
+    });
+
+    if (!geminiCandidates.length) {
+        return false;
+    }
+
+    return detectRecordedPlannedExpenseWithGemini(plannedExpense, geminiCandidates);
+}
+
+function findExactRecordedExpenseMatch(plannedExpense, candidateEntries) {
+    var plannedAmounts = extractPlannedExpenseAmounts(plannedExpense);
+    var plannedText = [plannedExpense.title || "", plannedExpense.memo || ""].join(" ");
+    var plannedNormalized = normalizeExpenseComparisonText(plannedText);
+
+    return candidateEntries.some(function (entry) {
+        var actualAmount = parseFloat(entry.amount);
+        var nameNormalized = normalizeExpenseComparisonText(entry.name || "");
+        var dayDistance = Math.abs(calculateDateDistanceInDays(plannedExpense.date, entry.date));
+        var exactAmountMatched = plannedAmounts.length && plannedAmounts.some(function (plannedAmount) {
+            return !isNaN(actualAmount) && plannedAmount === actualAmount;
+        });
+        var strongTextMatch = countSharedExpenseTokens(plannedText, [entry.name || "", entry.category || ""].join(" ")) >= 1 ||
+            (!!nameNormalized && plannedNormalized.indexOf(nameNormalized) !== -1);
+
+        return dayDistance === 0 && exactAmountMatched && strongTextMatch;
+    });
+}
+
+function isStrongExpenseCandidateForGemini(plannedExpense, entry) {
+    var plannedAmounts = extractPlannedExpenseAmounts(plannedExpense);
+    var actualAmount = parseFloat(entry.amount);
+    var dayDistance = Math.abs(calculateDateDistanceInDays(plannedExpense.date, entry.date));
+    var sharedTokenCount = countSharedExpenseTokens(
+        [plannedExpense.title || "", plannedExpense.memo || ""].join(" "),
+        [entry.name || "", entry.category || ""].join(" ")
+    );
+
+    if (dayDistance > 1) {
+        return false;
+    }
+
+    if (sharedTokenCount >= 1 && !plannedAmounts.length) {
+        return true;
+    }
+
+    return plannedAmounts.some(function (plannedAmount) {
+        return !isNaN(actualAmount) && Math.abs(plannedAmount - actualAmount) <= 300;
+    });
+}
+
+function detectRecordedPlannedExpenseWithGemini(plannedExpense, candidateEntries) {
+    var apiKey = getGeminiApiKey();
+    var prompt;
+    var responseText;
+    var normalized;
+
+    if (!apiKey) {
+        return false;
+    }
+
+    prompt = [
+        "以下のGoogleカレンダーの支出予定が、家計簿に記録済みの支出として扱ってよいか判定してください。",
+        "保守的に判定し、自信がない場合は NO にしてください。",
+        "出力は YES か NO のどちらか1語のみです。",
+        "予定:",
+        JSON.stringify({
+            date: formatDate(plannedExpense.date),
+            title: plannedExpense.title,
+            memo: plannedExpense.memo
+        }),
+        "家計簿候補:",
+        JSON.stringify(candidateEntries.map(function (entry) {
+            return {
+                date: formatDate(entry.date),
+                category: entry.category || "",
+                name: entry.name || "",
+                amount: entry.amount
+            };
+        }))
+    ].join("\n");
+
+    responseText = generateGeminiText(apiKey, prompt, {
+        temperature: 0,
+        maxOutputTokens: 10
+    });
+    if (!responseText) {
+        return false;
+    }
+
+    normalized = String(responseText).trim().toUpperCase();
+    Logger.log("予定支出の記録済みGemini判定: title=" + plannedExpense.title + " response=" + normalized);
+    return normalized.indexOf("YES") === 0;
+}
+
+function calculateDateDistanceInDays(leftDate, rightDate) {
+    var left = new Date(leftDate.getFullYear(), leftDate.getMonth(), leftDate.getDate());
+    var right = new Date(rightDate.getFullYear(), rightDate.getMonth(), rightDate.getDate());
+    return Math.round((left.getTime() - right.getTime()) / (24 * 60 * 60 * 1000));
 }
 
 function formatUpcomingPlannedExpenseLines(plannedExpenses) {

--- a/scripts/utils/expenseSummaryUtils.js
+++ b/scripts/utils/expenseSummaryUtils.js
@@ -46,14 +46,8 @@ function calculatePlannedExpenseTotal(plannedExpenses) {
     var total = 0;
 
     plannedExpenses.forEach(function (entry) {
-        var memo = entry.memo || "";
-        var matches = memo.match(/([0-9,]+)\s*円/g) || [];
-
-        matches.forEach(function (match) {
-            var amount = parseInt(match.replace(/[^\d]/g, ""), 10);
-            if (!isNaN(amount)) {
-                total += amount;
-            }
+        extractPlannedExpenseAmounts(entry).forEach(function (amount) {
+            total += amount;
         });
     });
 
@@ -66,4 +60,56 @@ function getTopExpenseEntries(dataEntries, limit) {
         return parseFloat(b.amount) - parseFloat(a.amount);
     });
     return topEntries.slice(0, limit);
+}
+
+function extractPlannedExpenseAmounts(entry) {
+    var combined = [entry.title || "", entry.memo || ""].join(" ");
+    var matches = combined.match(/([0-9,]+)\s*円/g) || [];
+
+    return matches
+        .map(function (match) {
+            return parseInt(match.replace(/[^\d]/g, ""), 10);
+        })
+        .filter(function (amount) {
+            return !isNaN(amount);
+        });
+}
+
+function normalizeExpenseComparisonText(text) {
+    return normalizeFullWidthNumbers(String(text || ""))
+        .toLowerCase()
+        .replace(/\s+/g, "")
+        .replace(/[!！?？\-ー_./／\\,，。、「」（）()【】\[\]:'"@#&]/g, "");
+}
+
+function tokenizeExpenseComparisonText(text) {
+    return normalizeFullWidthNumbers(String(text || ""))
+        .toLowerCase()
+        .replace(/[!！?？\-ー_./／\\,，。、「」（）()【】\[\]:'"@#&]/g, " ")
+        .split(/\s+/)
+        .map(function (token) {
+            return token.trim();
+        })
+        .filter(function (token) {
+            return token.length >= 2 && !/^\d+$/.test(token);
+        });
+}
+
+function countSharedExpenseTokens(leftText, rightText) {
+    var leftTokens = tokenizeExpenseComparisonText(leftText);
+    var rightTokenSet = {};
+    var sharedCount = 0;
+
+    tokenizeExpenseComparisonText(rightText).forEach(function (token) {
+        rightTokenSet[token] = true;
+    });
+
+    leftTokens.forEach(function (token) {
+        if (rightTokenSet[token]) {
+            sharedCount++;
+            delete rightTokenSet[token];
+        }
+    });
+
+    return sharedCount;
 }


### PR DESCRIPTION
## 概要
- Issue #65 の対応
- カレンダー上の支出予定のうち、家計簿に記録済みと判断できるものをサマリ表示から除外する
- 判定は保守的に行い、曖昧なものは残す

## 変更内容
- 予定支出の金額抽出・文字列正規化・語句重なり判定用の utility を追加
- 予定支出を取得した後に、家計簿実績との照合処理を追加
- 照合は以下の流れで実施
  - 予定日の当日または前後1日の実績を候補化
  - 金額一致または近似、名称・メモの語句重なりで候補を絞る
  - 明確一致はルールベースで除外
  - 曖昧なケースだけ Gemini に `YES/NO` 判定させる
- 記録済みと判定された予定は、日次/週次サマリや Gemini 分析に渡す予定支出一覧から除外

## 判定方針
- 安全側に倒し、誤って未来予定を消さないことを優先する
- 自信が持てない場合や Gemini 判定に失敗した場合は除外せず残す
- `美容院 5000円` のような比較的明確な予定は除外しやすくする
- `ランチ行くかも？多分1500円くらい？` のような曖昧な予定は、十分な根拠がなければ残す

## 期待される挙動
- 既に家計簿に記録した予定支出は、以後のサマリで二重に予定扱いされにくくなる
- 曖昧な予定は過剰除外されず、必要なら予定支出として残る

## 確認
- `npm run build`

カレンダーの支出予定がまだ未記録
<img width="800" height="829" alt="image" src="https://github.com/user-attachments/assets/48407639-9058-4a6a-a3ef-8ddd0bc74b03" />
今後の支出予定に「BOOKOFF」がある
<img width="562" height="686" alt="image" src="https://github.com/user-attachments/assets/b2e659b1-1e9e-4d71-b1ba-48af5ff57027" />

カレンダーの支出予定が記録済
<img width="738" height="473" alt="image" src="https://github.com/user-attachments/assets/915c2033-565c-4559-8664-d3c7fa0208e7" />
今後の支出予定から「BOOKOFF」が消えている
<img width="463" height="610" alt="image" src="https://github.com/user-attachments/assets/c046347c-7b53-48ae-82a2-957b9cd6351f" />

