### PR TITLE
日次分析メールに予算割合の帯グラフを追加

### DIFF
--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -2,14 +2,26 @@ function getDailyBudgetChartTheme(totalAmount, adjustedBudget) {
     var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
 
     if (percentage > 100) {
-        return { color: "#d93025", label: "超過" };
+        return { color: "#7f1d1d", overBudgetColor: "#4a1010", label: "超過" };
     }
 
-    if (percentage >= 70) {
-        return { color: "#f9ab00", label: "注意" };
+    if (percentage >= 90) {
+        return { color: "#b3261e", overBudgetColor: "#b3261e", label: "限界" };
     }
 
-    return { color: "#188038", label: "予算内" };
+    if (percentage >= 80) {
+        return { color: "#e53935", overBudgetColor: "#e53935", label: "危険" };
+    }
+
+    if (percentage >= 60) {
+        return { color: "#f4511e", overBudgetColor: "#f4511e", label: "警戒" };
+    }
+
+    if (percentage >= 40) {
+        return { color: "#f9ab00", overBudgetColor: "#f9ab00", label: "注意" };
+    }
+
+    return { color: "#188038", overBudgetColor: "#188038", label: "予算内" };
 }
 
 function buildDailyBudgetChartTitle(totalAmount, adjustedBudget) {
@@ -72,7 +84,7 @@ function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
         .setOption("titleTextStyle", { color: "#202124", fontSize: 15, bold: true })
         .setOption("legend", { position: "none" })
         .setOption("isStacked", true)
-        .setOption("colors", [chartTheme.color, "#b3261e", "#e8eaed"])
+        .setOption("colors", [chartTheme.color, chartTheme.overBudgetColor, "#e8eaed"])
         .setOption("hAxis", {
             viewWindow: { min: 0, max: chartMaximum },
             ticks: getDailyBudgetChartTicks(adjustedBudget, scalePercentage),

--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -23,8 +23,21 @@ function buildDailyBudgetChartTitle(totalAmount, adjustedBudget) {
     return title;
 }
 
-function getDailyBudgetChartTicks(adjustedBudget) {
-    return [0, 25, 50, 75, 100].map(function (percentage) {
+function getDailyBudgetChartScalePercentage(totalAmount, adjustedBudget) {
+    var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
+
+    return Math.max(100, Math.ceil(percentage / 25) * 25);
+}
+
+function getDailyBudgetChartTicks(adjustedBudget, scalePercentage) {
+    var percentages = [];
+    var percentage;
+
+    for (percentage = 0; percentage <= scalePercentage; percentage += 25) {
+        percentages.push(percentage);
+    }
+
+    return percentages.map(function (percentage) {
         return {
             v: adjustedBudget * percentage / 100,
             f: percentage + "%"
@@ -34,7 +47,8 @@ function getDailyBudgetChartTicks(adjustedBudget) {
 
 function getDailyBudgetChartAmounts(totalAmount, adjustedBudget) {
     return {
-        spent: Math.min(totalAmount, adjustedBudget),
+        withinBudget: Math.min(totalAmount, adjustedBudget),
+        overBudget: Math.max(totalAmount - adjustedBudget, 0),
         remaining: Math.max(adjustedBudget - totalAmount, 0)
     };
 }
@@ -42,11 +56,14 @@ function getDailyBudgetChartAmounts(totalAmount, adjustedBudget) {
 function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
     var chartTheme = getDailyBudgetChartTheme(totalAmount, adjustedBudget);
     var chartAmounts = getDailyBudgetChartAmounts(totalAmount, adjustedBudget);
+    var scalePercentage = getDailyBudgetChartScalePercentage(totalAmount, adjustedBudget);
+    var chartMaximum = adjustedBudget * scalePercentage / 100;
     var chartData = Charts.newDataTable()
         .addColumn(Charts.ColumnType.STRING, "週予算")
-        .addColumn(Charts.ColumnType.NUMBER, "実支出")
+        .addColumn(Charts.ColumnType.NUMBER, "予算内の支出")
+        .addColumn(Charts.ColumnType.NUMBER, "超過分")
         .addColumn(Charts.ColumnType.NUMBER, "残り")
-        .addRow(["今週", chartAmounts.spent, chartAmounts.remaining])
+        .addRow(["今週", chartAmounts.withinBudget, chartAmounts.overBudget, chartAmounts.remaining])
         .build();
     var chart = Charts.newBarChart()
         .setDataTable(chartData)
@@ -55,10 +72,10 @@ function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
         .setOption("titleTextStyle", { color: "#202124", fontSize: 15, bold: true })
         .setOption("legend", { position: "none" })
         .setOption("isStacked", true)
-        .setOption("colors", [chartTheme.color, "#e8eaed"])
+        .setOption("colors", [chartTheme.color, "#b3261e", "#e8eaed"])
         .setOption("hAxis", {
-            viewWindow: { min: 0, max: adjustedBudget },
-            ticks: getDailyBudgetChartTicks(adjustedBudget),
+            viewWindow: { min: 0, max: chartMaximum },
+            ticks: getDailyBudgetChartTicks(adjustedBudget, scalePercentage),
             gridlines: { color: "#dadce0" },
             baselineColor: "#dadce0"
         })

--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -23,28 +23,46 @@ function buildDailyBudgetChartTitle(totalAmount, adjustedBudget) {
     return title;
 }
 
+function getDailyBudgetChartTicks(adjustedBudget) {
+    return [0, 25, 50, 75, 100].map(function (percentage) {
+        return {
+            v: adjustedBudget * percentage / 100,
+            f: percentage + "%"
+        };
+    });
+}
+
+function getDailyBudgetChartAmounts(totalAmount, adjustedBudget) {
+    return {
+        spent: Math.min(totalAmount, adjustedBudget),
+        remaining: Math.max(adjustedBudget - totalAmount, 0)
+    };
+}
+
 function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
     var chartTheme = getDailyBudgetChartTheme(totalAmount, adjustedBudget);
-    var chartMaximum = Math.max(totalAmount, adjustedBudget, 1);
+    var chartAmounts = getDailyBudgetChartAmounts(totalAmount, adjustedBudget);
     var chartData = Charts.newDataTable()
-        .addColumn(Charts.ColumnType.STRING, "区分")
-        .addColumn(Charts.ColumnType.NUMBER, "金額")
-        .addRow(["実支出", totalAmount])
+        .addColumn(Charts.ColumnType.STRING, "週予算")
+        .addColumn(Charts.ColumnType.NUMBER, "実支出")
+        .addColumn(Charts.ColumnType.NUMBER, "残り")
+        .addRow(["今週", chartAmounts.spent, chartAmounts.remaining])
         .build();
     var chart = Charts.newBarChart()
         .setDataTable(chartData)
-        .setDimensions(600, 120)
+        .setDimensions(600, 160)
         .setOption("title", buildDailyBudgetChartTitle(totalAmount, adjustedBudget))
         .setOption("titleTextStyle", { color: "#202124", fontSize: 15, bold: true })
         .setOption("legend", { position: "none" })
-        .setOption("colors", [chartTheme.color])
+        .setOption("isStacked", true)
+        .setOption("colors", [chartTheme.color, "#e8eaed"])
         .setOption("hAxis", {
-            viewWindow: { min: 0, max: chartMaximum },
-            textPosition: "none",
-            gridlines: { color: "transparent" },
+            viewWindow: { min: 0, max: adjustedBudget },
+            ticks: getDailyBudgetChartTicks(adjustedBudget),
+            gridlines: { color: "#dadce0" },
             baselineColor: "#dadce0"
         })
-        .setOption("chartArea", { left: 70, top: 44, width: "82%", height: "32%" })
+        .setOption("chartArea", { left: 70, top: 44, width: "82%", height: "48%" })
         .build();
 
     return chart.getAs("image/png").setName("daily-budget-chart.png");

--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -26,13 +26,12 @@ function getDailyBudgetChartTheme(totalAmount, adjustedBudget) {
 
 function buildDailyBudgetChartTitle(totalAmount, adjustedBudget) {
     var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
-    var title = "今週の実支出 " + totalAmount + "円 / " + adjustedBudget + "円（" + percentage.toFixed(1) + "%）";
 
     if (totalAmount > adjustedBudget) {
-        title += "  " + (totalAmount - adjustedBudget) + "円超過";
+        return "【緊急】週予算の" + (totalAmount / adjustedBudget).toFixed(1) + "倍（" + (totalAmount - adjustedBudget) + "円超過）";
     }
 
-    return title;
+    return "今週の実支出 " + totalAmount + "円 / " + adjustedBudget + "円（" + percentage.toFixed(1) + "%）";
 }
 
 function getDailyBudgetChartScalePercentage(totalAmount, adjustedBudget) {
@@ -42,7 +41,7 @@ function getDailyBudgetChartScalePercentage(totalAmount, adjustedBudget) {
 }
 
 function getDailyBudgetChartTickStep(scalePercentage) {
-    if (scalePercentage > 400) {
+    if (scalePercentage > 300) {
         return 100;
     }
 
@@ -65,7 +64,7 @@ function getDailyBudgetChartTicks(adjustedBudget, scalePercentage) {
     return percentages.map(function (percentage) {
         return {
             v: adjustedBudget * percentage / 100,
-            f: percentage + "%"
+            f: percentage === 100 && scalePercentage > 200 ? "100% 予算上限" : percentage + "%"
         };
     });
 }
@@ -73,7 +72,8 @@ function getDailyBudgetChartTicks(adjustedBudget, scalePercentage) {
 function getDailyBudgetChartAmounts(totalAmount, adjustedBudget) {
     return {
         withinBudget: Math.min(totalAmount, adjustedBudget),
-        overBudget: Math.max(totalAmount - adjustedBudget, 0),
+        overBudget: Math.min(Math.max(totalAmount - adjustedBudget, 0), adjustedBudget / 2),
+        criticalOverBudget: Math.max(totalAmount - adjustedBudget * 1.5, 0),
         remaining: Math.max(adjustedBudget - totalAmount, 0)
     };
 }
@@ -86,18 +86,19 @@ function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
     var chartData = Charts.newDataTable()
         .addColumn(Charts.ColumnType.STRING, "週予算")
         .addColumn(Charts.ColumnType.NUMBER, "予算内の支出")
-        .addColumn(Charts.ColumnType.NUMBER, "超過分")
+        .addColumn(Charts.ColumnType.NUMBER, "超過分（100〜150%）")
+        .addColumn(Charts.ColumnType.NUMBER, "超過分（150%超）")
         .addColumn(Charts.ColumnType.NUMBER, "残り")
-        .addRow(["今週", chartAmounts.withinBudget, chartAmounts.overBudget, chartAmounts.remaining])
+        .addRow(["今週", chartAmounts.withinBudget, chartAmounts.overBudget, chartAmounts.criticalOverBudget, chartAmounts.remaining])
         .build();
     var chart = Charts.newBarChart()
         .setDataTable(chartData)
         .setDimensions(600, 160)
         .setOption("title", buildDailyBudgetChartTitle(totalAmount, adjustedBudget))
-        .setOption("titleTextStyle", { color: "#202124", fontSize: 15, bold: true })
+        .setOption("titleTextStyle", { color: totalAmount > adjustedBudget ? "#b42318" : "#202124", fontSize: 15, bold: true })
         .setOption("legend", { position: "none" })
         .setOption("isStacked", true)
-        .setOption("colors", [chartTheme.color, chartTheme.overBudgetColor, "#e8eaed"])
+        .setOption("colors", [chartTheme.color, chartTheme.overBudgetColor, "#6b1512", "#e8eaed"])
         .setOption("hAxis", {
             viewWindow: { min: 0, max: chartMaximum },
             ticks: getDailyBudgetChartTicks(adjustedBudget, scalePercentage),

--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -2,11 +2,11 @@ function getDailyBudgetChartTheme(totalAmount, adjustedBudget) {
     var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
 
     if (percentage > 100) {
-        return { color: "#7f1d1d", overBudgetColor: "#4a1010", label: "超過" };
+        return { color: "#b42318", overBudgetColor: "#8c1d18", label: "超過" };
     }
 
     if (percentage >= 90) {
-        return { color: "#b3261e", overBudgetColor: "#b3261e", label: "限界" };
+        return { color: "#c62828", overBudgetColor: "#c62828", label: "限界" };
     }
 
     if (percentage >= 80) {
@@ -41,11 +41,24 @@ function getDailyBudgetChartScalePercentage(totalAmount, adjustedBudget) {
     return Math.max(100, Math.ceil(percentage / 25) * 25);
 }
 
+function getDailyBudgetChartTickStep(scalePercentage) {
+    if (scalePercentage > 400) {
+        return 100;
+    }
+
+    if (scalePercentage > 200) {
+        return 50;
+    }
+
+    return 25;
+}
+
 function getDailyBudgetChartTicks(adjustedBudget, scalePercentage) {
     var percentages = [];
     var percentage;
+    var tickStep = getDailyBudgetChartTickStep(scalePercentage);
 
-    for (percentage = 0; percentage <= scalePercentage; percentage += 25) {
+    for (percentage = 0; percentage <= scalePercentage; percentage += tickStep) {
         percentages.push(percentage);
     }
 

--- a/scripts/formatting/dailyBudgetChart.js
+++ b/scripts/formatting/dailyBudgetChart.js
@@ -1,0 +1,73 @@
+function getDailyBudgetChartTheme(totalAmount, adjustedBudget) {
+    var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
+
+    if (percentage > 100) {
+        return { color: "#d93025", label: "超過" };
+    }
+
+    if (percentage >= 70) {
+        return { color: "#f9ab00", label: "注意" };
+    }
+
+    return { color: "#188038", label: "予算内" };
+}
+
+function buildDailyBudgetChartTitle(totalAmount, adjustedBudget) {
+    var percentage = adjustedBudget ? (totalAmount / adjustedBudget) * 100 : 0;
+    var title = "今週の実支出 " + totalAmount + "円 / " + adjustedBudget + "円（" + percentage.toFixed(1) + "%）";
+
+    if (totalAmount > adjustedBudget) {
+        title += "  " + (totalAmount - adjustedBudget) + "円超過";
+    }
+
+    return title;
+}
+
+function createDailyBudgetChartBlob(totalAmount, adjustedBudget) {
+    var chartTheme = getDailyBudgetChartTheme(totalAmount, adjustedBudget);
+    var chartMaximum = Math.max(totalAmount, adjustedBudget, 1);
+    var chartData = Charts.newDataTable()
+        .addColumn(Charts.ColumnType.STRING, "区分")
+        .addColumn(Charts.ColumnType.NUMBER, "金額")
+        .addRow(["実支出", totalAmount])
+        .build();
+    var chart = Charts.newBarChart()
+        .setDataTable(chartData)
+        .setDimensions(600, 120)
+        .setOption("title", buildDailyBudgetChartTitle(totalAmount, adjustedBudget))
+        .setOption("titleTextStyle", { color: "#202124", fontSize: 15, bold: true })
+        .setOption("legend", { position: "none" })
+        .setOption("colors", [chartTheme.color])
+        .setOption("hAxis", {
+            viewWindow: { min: 0, max: chartMaximum },
+            textPosition: "none",
+            gridlines: { color: "transparent" },
+            baselineColor: "#dadce0"
+        })
+        .setOption("chartArea", { left: 70, top: 44, width: "82%", height: "32%" })
+        .build();
+
+    return chart.getAs("image/png").setName("daily-budget-chart.png");
+}
+
+function buildDailySummaryHtmlBody(body, totalAmount, adjustedBudget) {
+    var chartTitle = buildDailyBudgetChartTitle(totalAmount, adjustedBudget);
+
+    return (
+        '<img src="cid:dailyBudgetChart" alt="' +
+        escapeHtmlForEmail(chartTitle) +
+        '" width="600" style="display:block;max-width:100%;height:auto;margin:0 0 16px;">' +
+        '<pre style="font-family:monospace;white-space:pre-wrap;line-height:1.5;">' +
+        escapeHtmlForEmail(body) +
+        "</pre>"
+    );
+}
+
+function escapeHtmlForEmail(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}

--- a/scripts/formatting/summaryMessageFormatter.js
+++ b/scripts/formatting/summaryMessageFormatter.js
@@ -167,7 +167,16 @@ function handleDailySummaryResult(currentDate, datesInWeek, adjustedBudget, isSt
     switch (action) {
         case 'mail':
             var emailAddress = getTargetEmailAddress();
-            MailApp.sendEmail(emailAddress, subject, body);
+            var dailyBudgetChart = createDailyBudgetChartBlob(totalAmount, adjustedBudget);
+            MailApp.sendEmail({
+                to: emailAddress,
+                subject: subject,
+                body: body,
+                htmlBody: buildDailySummaryHtmlBody(body, totalAmount, adjustedBudget),
+                inlineImages: {
+                    dailyBudgetChart: dailyBudgetChart
+                }
+            });
             return "Successfully sent mail";
         case 'text':
             return body;

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -32,25 +32,33 @@ test('日次予算グラフのタイトルは超過額を明示する', () => {
     );
 });
 
-test('日次予算グラフは予算を100%として支出と残りを分ける', () => {
+test('日次予算グラフは予算内・超過・残りを分ける', () => {
     const chart = loadChartFunctions();
 
-    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).spent, 9400);
+    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).withinBudget, 9400);
+    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).overBudget, 0);
     assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).remaining, 30600);
-    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).spent, 40000);
+    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).withinBudget, 40000);
+    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).overBudget, 3400);
     assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).remaining, 0);
 });
 
-test('日次予算グラフは0%から100%までを25%刻みで表示する', () => {
+test('日次予算グラフは超過時に25%刻みで表示範囲を広げる', () => {
     const chart = loadChartFunctions();
-    const ticks = chart.getDailyBudgetChartTicks(40000);
+    const ticks = chart.getDailyBudgetChartTicks(40000, chart.getDailyBudgetChartScalePercentage(64400, 40000));
 
+    assert.equal(chart.getDailyBudgetChartScalePercentage(40000, 40000), 100);
+    assert.equal(chart.getDailyBudgetChartScalePercentage(40100, 40000), 125);
+    assert.equal(chart.getDailyBudgetChartScalePercentage(64400, 40000), 175);
     assert.equal(JSON.stringify(ticks), JSON.stringify([
         { v: 0, f: '0%' },
         { v: 10000, f: '25%' },
         { v: 20000, f: '50%' },
         { v: 30000, f: '75%' },
-        { v: 40000, f: '100%' }
+        { v: 40000, f: '100%' },
+        { v: 50000, f: '125%' },
+        { v: 60000, f: '150%' },
+        { v: 70000, f: '175%' }
     ]));
 });
 

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -15,11 +15,14 @@ function loadChartFunctions() {
 test('日次予算グラフは支出割合に応じた色を返す', () => {
     const chart = loadChartFunctions();
 
-    assert.equal(chart.getDailyBudgetChartTheme(27000, 40000).color, '#188038');
-    assert.equal(chart.getDailyBudgetChartTheme(27000, 40000).label, '予算内');
-    assert.equal(chart.getDailyBudgetChartTheme(28000, 40000).color, '#f9ab00');
-    assert.equal(chart.getDailyBudgetChartTheme(28000, 40000).label, '注意');
-    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).color, '#d93025');
+    assert.equal(chart.getDailyBudgetChartTheme(15600, 40000).color, '#188038');
+    assert.equal(chart.getDailyBudgetChartTheme(15600, 40000).label, '予算内');
+    assert.equal(chart.getDailyBudgetChartTheme(16000, 40000).color, '#f9ab00');
+    assert.equal(chart.getDailyBudgetChartTheme(24000, 40000).color, '#f4511e');
+    assert.equal(chart.getDailyBudgetChartTheme(32000, 40000).color, '#e53935');
+    assert.equal(chart.getDailyBudgetChartTheme(36000, 40000).color, '#b3261e');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).color, '#7f1d1d');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).overBudgetColor, '#4a1010');
     assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).label, '超過');
 });
 

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -31,7 +31,7 @@ test('日次予算グラフのタイトルは超過額を明示する', () => {
 
     assert.equal(
         chart.buildDailyBudgetChartTitle(43400, 40000),
-        '今週の実支出 43400円 / 40000円（108.5%）  3400円超過'
+        '【緊急】週予算の1.1倍（3400円超過）'
     );
 });
 
@@ -40,10 +40,14 @@ test('日次予算グラフは予算内・超過・残りを分ける', () => {
 
     assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).withinBudget, 9400);
     assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).overBudget, 0);
+    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).criticalOverBudget, 0);
     assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).remaining, 30600);
     assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).withinBudget, 40000);
     assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).overBudget, 3400);
+    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).criticalOverBudget, 0);
     assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).remaining, 0);
+    assert.equal(chart.getDailyBudgetChartAmounts(159400, 40000).overBudget, 20000);
+    assert.equal(chart.getDailyBudgetChartAmounts(159400, 40000).criticalOverBudget, 99400);
 });
 
 test('日次予算グラフは超過時に25%刻みで表示範囲を広げる', () => {
@@ -70,17 +74,13 @@ test('日次予算グラフは大幅超過時に目盛りの間隔を広げる',
     const ticks = chart.getDailyBudgetChartTicks(40000, 400);
 
     assert.equal(chart.getDailyBudgetChartTickStep(200), 25);
-    assert.equal(chart.getDailyBudgetChartTickStep(400), 50);
-    assert.equal(chart.getDailyBudgetChartTickStep(425), 100);
+    assert.equal(chart.getDailyBudgetChartTickStep(300), 50);
+    assert.equal(chart.getDailyBudgetChartTickStep(400), 100);
     assert.equal(JSON.stringify(ticks), JSON.stringify([
         { v: 0, f: '0%' },
-        { v: 20000, f: '50%' },
-        { v: 40000, f: '100%' },
-        { v: 60000, f: '150%' },
+        { v: 40000, f: '100% 予算上限' },
         { v: 80000, f: '200%' },
-        { v: 100000, f: '250%' },
         { v: 120000, f: '300%' },
-        { v: 140000, f: '350%' },
         { v: 160000, f: '400%' }
     ]));
 });

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadChartFunctions() {
+    const context = {};
+    vm.runInNewContext(
+        fs.readFileSync('scripts/formatting/dailyBudgetChart.js', 'utf8'),
+        context
+    );
+    return context;
+}
+
+test('日次予算グラフは支出割合に応じた色を返す', () => {
+    const chart = loadChartFunctions();
+
+    assert.equal(chart.getDailyBudgetChartTheme(27000, 40000).color, '#188038');
+    assert.equal(chart.getDailyBudgetChartTheme(27000, 40000).label, '予算内');
+    assert.equal(chart.getDailyBudgetChartTheme(28000, 40000).color, '#f9ab00');
+    assert.equal(chart.getDailyBudgetChartTheme(28000, 40000).label, '注意');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).color, '#d93025');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).label, '超過');
+});
+
+test('日次予算グラフのタイトルは超過額を明示する', () => {
+    const chart = loadChartFunctions();
+
+    assert.equal(
+        chart.buildDailyBudgetChartTitle(43400, 40000),
+        '今週の実支出 43400円 / 40000円（108.5%）  3400円超過'
+    );
+});
+
+test('HTMLメール本文はグラフを先頭に置き、テキスト本文をエスケープする', () => {
+    const chart = loadChartFunctions();
+    const html = chart.buildDailySummaryHtmlBody('支出: <1000>円 & 確認', 1000, 40000);
+
+    assert.match(html, /^<img src="cid:dailyBudgetChart"/);
+    assert.match(html, /支出: &lt;1000&gt;円 &amp; 確認/);
+});

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -32,6 +32,28 @@ test('日次予算グラフのタイトルは超過額を明示する', () => {
     );
 });
 
+test('日次予算グラフは予算を100%として支出と残りを分ける', () => {
+    const chart = loadChartFunctions();
+
+    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).spent, 9400);
+    assert.equal(chart.getDailyBudgetChartAmounts(9400, 40000).remaining, 30600);
+    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).spent, 40000);
+    assert.equal(chart.getDailyBudgetChartAmounts(43400, 40000).remaining, 0);
+});
+
+test('日次予算グラフは0%から100%までを25%刻みで表示する', () => {
+    const chart = loadChartFunctions();
+    const ticks = chart.getDailyBudgetChartTicks(40000);
+
+    assert.equal(JSON.stringify(ticks), JSON.stringify([
+        { v: 0, f: '0%' },
+        { v: 10000, f: '25%' },
+        { v: 20000, f: '50%' },
+        { v: 30000, f: '75%' },
+        { v: 40000, f: '100%' }
+    ]));
+});
+
 test('HTMLメール本文はグラフを先頭に置き、テキスト本文をエスケープする', () => {
     const chart = loadChartFunctions();
     const html = chart.buildDailySummaryHtmlBody('支出: <1000>円 & 確認', 1000, 40000);

--- a/test/dailyBudgetChart.test.js
+++ b/test/dailyBudgetChart.test.js
@@ -20,9 +20,9 @@ test('日次予算グラフは支出割合に応じた色を返す', () => {
     assert.equal(chart.getDailyBudgetChartTheme(16000, 40000).color, '#f9ab00');
     assert.equal(chart.getDailyBudgetChartTheme(24000, 40000).color, '#f4511e');
     assert.equal(chart.getDailyBudgetChartTheme(32000, 40000).color, '#e53935');
-    assert.equal(chart.getDailyBudgetChartTheme(36000, 40000).color, '#b3261e');
-    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).color, '#7f1d1d');
-    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).overBudgetColor, '#4a1010');
+    assert.equal(chart.getDailyBudgetChartTheme(36000, 40000).color, '#c62828');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).color, '#b42318');
+    assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).overBudgetColor, '#8c1d18');
     assert.equal(chart.getDailyBudgetChartTheme(40001, 40000).label, '超過');
 });
 
@@ -62,6 +62,26 @@ test('日次予算グラフは超過時に25%刻みで表示範囲を広げる',
         { v: 50000, f: '125%' },
         { v: 60000, f: '150%' },
         { v: 70000, f: '175%' }
+    ]));
+});
+
+test('日次予算グラフは大幅超過時に目盛りの間隔を広げる', () => {
+    const chart = loadChartFunctions();
+    const ticks = chart.getDailyBudgetChartTicks(40000, 400);
+
+    assert.equal(chart.getDailyBudgetChartTickStep(200), 25);
+    assert.equal(chart.getDailyBudgetChartTickStep(400), 50);
+    assert.equal(chart.getDailyBudgetChartTickStep(425), 100);
+    assert.equal(JSON.stringify(ticks), JSON.stringify([
+        { v: 0, f: '0%' },
+        { v: 20000, f: '50%' },
+        { v: 40000, f: '100%' },
+        { v: 60000, f: '150%' },
+        { v: 80000, f: '200%' },
+        { v: 100000, f: '250%' },
+        { v: 120000, f: '300%' },
+        { v: 140000, f: '350%' },
+        { v: 160000, f: '400%' }
     ]));
 });
 


### PR DESCRIPTION
<img width="656" height="266" alt="image" src="https://github.com/user-attachments/assets/019220bf-0fde-4970-a134-2b301946b38c" />
<img width="656" height="266" alt="image" src="https://github.com/user-attachments/assets/0d8061c9-f7c6-4a30-b541-1043e7b88c91" />
<img width="656" height="266" alt="image" src="https://github.com/user-attachments/assets/2e1985f3-7661-4d73-93c3-a3a91a613244" />
<img width="656" height="266" alt="image" src="https://github.com/user-attachments/assets/ac3ab4f8-2bf8-4786-8451-ffa0d4c69ada" />
<img width="656" height="266" alt="image" src="https://github.com/user-attachments/assets/e0431fda-b2d4-43f8-a8de-bedaabfeb84b" />
